### PR TITLE
json5 0.9.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "json5" %}
-{% set version = "0.9.6" %}
+{% set version = "0.9.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9175ad1bc248e22bb8d95a8e8d765958bf0008fef2fe8abab5bc04e0f1ac8302
+  sha256: 4f1e196acc55b83985a51318489f345963c7ba84aa37607e49073066c562e99b
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 3dbfb1b..320812e 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "json5" %}
-{% set version = "0.9.6" %}
+{% set version = "0.9.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9175ad1bc248e22bb8d95a8e8d765958bf0008fef2fe8abab5bc04e0f1ac8302
+  sha256: 4f1e196acc55b83985a51318489f345963c7ba84aa37607e49073066c562e99b
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.9.11
 * Release on PyPi:
    * version: 0.9.11
    * date: 2023-01-03T02:55:41
* [PyPi history](https://pypi.org/project/json5/#history)
 * Popularity: 
    * 3 months downloads: 562163.0
    * All time:  4102681 downloads -  json5  0.9.5  A Python implementation of the JSON5 data format  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/dpranke/pyjson5/tree/v0.9.11 exists
2. - [ ] The upstream url error:
    https://github.com/dpranke/pyjson5
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/dpranke/pyjson5/tree/v0.9.11
    200
5. - [ ] Additional research
    https://github.com/dpranke/pyjson5/issues
    
6. - [ ] `dev_url` error:
    https://github.com/dpranke/pyjson5
    
7. - [ ] `doc_url` error:
    
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present

16. - [x] license_family Apache is present
17. - [x] License: Apache-2.0
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|:-------------|
| Apache-2.0   |
</details>

**Check dependency issues:**

<details>
../aggregate/json5-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'python', 'setuptools', 'wheel']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 17**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/json5-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/json5-feedstock/tree/0.9.11)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/json5)
* [Diff between upstream and feature branch](https://github.com/conda-forge/json5-feedstock/compare/main...AnacondaRecipes:0.9.11)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/json5-feedstock/compare/master...AnacondaRecipes:0.9.11)
* [The last merged PRs](https://github.com/AnacondaRecipes/json5-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.9.11 git@github.com:AnacondaRecipes/json5-feedstock.git
```
