### PR TITLE
json5 0.9.25

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "json5" %}
-{% set version = "0.9.6" %}
+{% set version = "0.9.25" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9175ad1bc248e22bb8d95a8e8d765958bf0008fef2fe8abab5bc04e0f1ac8302
+  sha256: 548e41b9be043f9426776f05df8635a00fe06104ea51ed24b67f908856e151ae
 
 build:
   number: 0
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv "
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - pyjson5 = json5.tool:main
 
@@ -37,6 +36,7 @@ test:
     - pip
   commands:
     - pip check
+    - pyjson5 --help
 
 about:
   home: https://github.com/dpranke/pyjson5
@@ -44,6 +44,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: A Python implementation of the JSON5 data format
+  description: A Python implementation of the JSON5 data format
   dev_url: https://github.com/dpranke/pyjson5
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ about:
   summary: A Python implementation of the JSON5 data format
   description: A Python implementation of the JSON5 data format
   dev_url: https://github.com/dpranke/pyjson5
+  doc_url: https://github.com/dpranke/pyjson5
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5696](https://anaconda.atlassian.net/browse/PKG-5696)
- [Upstream repo](https://github.com/dpranke/pyjson5/tree/v0.9.25)
- release-diff: https://github.com/dpranke/pyjson5/compare/v0.9.25...v0.9.6
- license: https://github.com/dpranke/pyjson5/blob/main/LICENSE
- requirements-tagged:
  - https://github.com/dpranke/pyjson5/blob/v0.9.25/pyproject.toml


### Explanation of changes:

-

[PKG-5696]: https://anaconda.atlassian.net/browse/PKG-5696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ